### PR TITLE
Allow reply_broadcast option to be configured

### DIFF
--- a/actions/index.js
+++ b/actions/index.js
@@ -170,12 +170,10 @@ export const sendStandupSummaryEmail = async (standup) => {
     fragments.push(`
       <tr style="background: ${alternateBackground()};">
         <td width="120" style="padding: 10px 0; text-align: center;">
-          <img width="72" style="border-radius: 50%" src="${
-            user.profile.image_192
-          }">
-          <p style="margin:0; font-weight: bold;">${
-            user.profile.display_name
-          }</p>
+          <img width="72" style="border-radius: 50%" src="${user.profile.image_192
+      }">
+          <p style="margin:0; font-weight: bold;">${user.profile.display_name
+      }</p>
         </td>
         <td style="padding-top: 10px">${updates}</td>
       </tr>
@@ -186,9 +184,8 @@ export const sendStandupSummaryEmail = async (standup) => {
 <html>
 <head></head>
 <body style="padding: 5px;">
-  <h1 style="margin: 0; font-size: 16px; font-weight: normal; padding: 5px; border-bottom: 1px solid #444;">Today's standup summary for <b>${
-    channel.name
-  }</b></h1>
+  <h1 style="margin: 0; font-size: 16px; font-weight: normal; padding: 5px; border-bottom: 1px solid #444;">Today's standup summary for <b>${channel.name
+    }</b></h1>
   <table cellspacing="0" width="100%">${fragments.join('')}</table>
 </body>
   `;
@@ -365,6 +362,7 @@ export const startStandup = async (room) => {
     year: now.year,
     endTime: sequelize.literal(`datetime('now', '+${room.length} minutes')`),
     threaded: room.threading,
+    broadcast: room.broadcast,
   });
 
   if (aways.length) {
@@ -410,7 +408,7 @@ export const startStandup = async (room) => {
 
     await client.say(room.channelId, ping, {
       thread_ts: resp.ts,
-      reply_broadcast: true,
+      reply_broadcast: room.broadcast,
     });
 
     await client.pin(room.channelId, resp.ts);
@@ -672,12 +670,12 @@ export const getDeliquentUserIds = async (standup) => {
 
   const options = filterIds.length
     ? {
-        where: {
-          id: {
-            $notIn: filterIds,
-          },
+      where: {
+        id: {
+          $notIn: filterIds,
         },
-      }
+      },
+    }
     : {};
 
   const users = await getActiveRoomUsers(standup.room, options);
@@ -722,7 +720,7 @@ export const warnStandup = async (standup) => {
   const NICK = await client.nick();
 
   const opts = standup.threaded
-    ? { thread_ts: standup.threadRoot, reply_broadcast: true }
+    ? { thread_ts: standup.threadRoot, reply_broadcast: standup.broadcast }
     : {};
 
   await client.say(
@@ -778,7 +776,7 @@ export const threatenStandup = async (standup) => {
   const NICK = await client.nick();
 
   const opts = standup.threaded
-    ? { thread_ts: standup.threadRoot, reply_broadcast: true }
+    ? { thread_ts: standup.threadRoot, reply_broadcast: standup.broadcast }
     : {};
 
   await client.say(

--- a/commands/broadcast.js
+++ b/commands/broadcast.js
@@ -1,0 +1,43 @@
+import client from '../lib/client';
+import { Room } from '../lib/db';
+
+import { getRoomAndStandupAndUser } from '../actions';
+
+export default async function (userId, channelId, rawFlag, rawMessage) {
+  const [room] = await getRoomAndStandupAndUser(channelId, userId);
+  const flag = rawFlag.trim();
+
+  if (flag !== 'on' && flag !== 'off') {
+    client.sayAt(
+      channelId,
+      userId,
+      "I don't understand. Set the broadcast option using `on` or `off`."
+    );
+    return;
+  }
+
+  if (!room) {
+    client.sayAt(
+      channelId,
+      userId,
+      "Oops, this room doesn't have any standups scheduled. See .standup help for more info."
+    );
+    return;
+  }
+
+  const broadcast = flag === 'on';
+  const message = broadcast
+    ? 'Ok, threaded standupbot replies will be shared to channel.'
+    : 'Ok, threaded standupbot replies will no longer be shared to channel.';
+
+  Room.update(
+    {
+      broadcast,
+    },
+    { where: { channelId } }
+  ).then(() => {
+    client.sayAt(channelId, userId, message, {
+      thread_ts: rawMessage.thread_ts,
+    });
+  });
+}

--- a/commands/help.js
+++ b/commands/help.js
@@ -1,6 +1,6 @@
 import client from '../lib/client';
 
-export default function(userId, channelId, arg, rawMessage) {
+export default function (userId, channelId, arg, rawMessage) {
   const out = [
     'Here are the commands I respond to.',
     '*.standup add &lt;@user&gt;* _Add a user to the standup. Adding multiple users at once is supported._',
@@ -18,6 +18,7 @@ export default function(userId, channelId, arg, rawMessage) {
     '*.standup email <ldap>* _Send the standup summary via email._',
     '*.standup announce <off|on>* _Set whether to announce the start/end of the standup in the channel._',
     '*.standup threading <off|on>* _Set whether to use a Slack thread for the standup._',
+    '*.standup broadcast <off|on>* _Set whether to send threaded Slackbot reples to the channel._',
   ];
 
   client.sayAt(channelId, userId, out.join('\n'), {

--- a/commands/index.js
+++ b/commands/index.js
@@ -1,5 +1,6 @@
 import add from './add';
 import announce from './announce';
+import broadcast from './broadcast';
 import cancel from './cancel';
 import email from './email';
 import end from './end';
@@ -16,6 +17,7 @@ import update from './update';
 export {
   add,
   announce,
+  broadcast,
   cancel,
   email,
   end,

--- a/constants/index.js
+++ b/constants/index.js
@@ -11,6 +11,7 @@ export default {
   COMMANDS: [
     'add',
     'announce',
+    'broadcast',
     'end',
     'remove',
     'update',

--- a/lib/db.js
+++ b/lib/db.js
@@ -50,6 +50,10 @@ export const Room = sequelize.define('room', {
     type: Sequelize.BOOLEAN,
     defaultValue: true,
   },
+  broadcast: {
+    type: Sequelize.BOOLEAN,
+    defaultValue: true,
+  },
 });
 
 export const User = sequelize.define('user', {
@@ -155,6 +159,10 @@ export const Standup = sequelize.define(
     threadRoot: {
       type: Sequelize.STRING,
     },
+    broadcast: {
+      type: Sequelize.BOOLEAN,
+      defaultValue: true,
+    }
   },
   {
     scopes: {


### PR DESCRIPTION
Standup bot messages broadcasted to the channel can be noisy.

This PR allows the reply_broadcast to be configured for usage with threaded standups.

<img width="1051" alt="Screen Shot 2021-08-12 at 9 53 10 AM" src="https://user-images.githubusercontent.com/20505588/129209172-6539c9f8-46fb-4b77-bd2e-4b082734ef91.png">
