### PR TITLE
Removing User Formatter Call To Take Out Summary @/Mentions

### DIFF
--- a/actions/index.js
+++ b/actions/index.js
@@ -122,7 +122,7 @@ export const closeStandup = async (standup) => {
     for (let i = 0; i < updates.length; i++) {
       const update = updates[i];
       const message = await formatUpdateMessage(update);
-      out.push(`${u(update.user.userId)}: ${message}`);
+      out.push(`${update.user.userId}: ${message}`);
     }
 
     const summary = out.join('\n');

--- a/actions/index.js
+++ b/actions/index.js
@@ -122,7 +122,8 @@ export const closeStandup = async (standup) => {
     for (let i = 0; i < updates.length; i++) {
       const update = updates[i];
       const message = await formatUpdateMessage(update);
-      out.push(`${update.user.userId}: ${message}`);
+      const slackUser = await client.getUser(update.user.userId);
+      out.push(`${slackUser.profile.display_name}: ${message}`);
     }
 
     const summary = out.join('\n');


### PR DESCRIPTION
#### Background information
Standup Bot summarizes all user messages but there is an unnecessary mention when the standup concludes. This pr will address that issue by removing the user function call from the summary section.

#### Implementation Summary
Removed the formatter function from the summary call 

#### Steps to Test

1. schedule and start a standup
2. Wait for standup to end
3. See if Standup bot mentions the user when the summary is posted

####  Risk mitigation
Low risk because functionality will not change. More of a quality of life change